### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration
+version: 2
+updates:
+  # Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "⬆ "
+      prefix-development: "⬆ [dev] "
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
This sets up Dependabot for Python dependencies. This closes #24.

We can probably do some more intelligent grouping in the future and switch to the "auto" versioning strategy once this package is published to PyPI, but this should be a good start to get notified of new dependency updates.