### PR TITLE
Further loosen dependency requirements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2062,4 +2062,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "7a7243f7fc83783cc66d186759d951b8d403f81ec6104b682848c21408ac2a3c"
+content-hash = "042bb55f2d9f1c70516ba297de8bd430b7e7fca941d4561f3abc934f0f6bc478"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ coverage = { version = "==7.3.2", extras = ["toml"] }
 pytest = "==8.0.0"
 pyright = "==1.1.350"
 ruff = "==0.2.1"
-pandas-stubs = "^2.1.4.231227"
+pandas-stubs = "==2.1.4.231227"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
I realized that we still listed relatively strict dependency versions. I went ahead and fully loosened them and all tests pass for Python 3.9-3.12. I'd suggest we start with this strategy and if any future implemented tests fail on certain versions, we can manually exclude those.