### PR TITLE
Sort imports and expand pyright coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ src = ["src"]
 target-version = "py39"
 
 [tool.ruff.lint]
-# On top of the default `select` (E, F), enable pydocstyle (D), pycodestyle Warning (W).
-extend-select = ["D", "W"]
+# On top of the default `select` (E, F), enable pydocstyle (D), isort (I), pycodestyle Warning (W).
+extend-select = ["D", "I", "W"]
 
 # Ignore redundant rules when using formatter
 ignore = ["D206", "D300", "W191"]
@@ -54,7 +54,6 @@ ignore = ["D206", "D300", "W191"]
 convention = "google"
 
 [tool.pyright]
-include = ["src"]
 typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]

--- a/src/vhip/mlmodel/genomes_features.py
+++ b/src/vhip/mlmodel/genomes_features.py
@@ -6,8 +6,9 @@ This module provides:
 - HomologyMatch: check for DNA sequence match between a virus and host from blastn files
 """
 
-import numpy as np
 from typing import List
+
+import numpy as np
 
 
 class KmerProfile:

--- a/src/vhip/mlmodel/read_sequence.py
+++ b/src/vhip/mlmodel/read_sequence.py
@@ -5,8 +5,9 @@ This module provides:
 - read_headers: retrieve the headers for fasta path
 """
 
-from Bio import SeqIO  # pyright: ignore[reportMissingTypeStubs]
 from typing import List
+
+from Bio import SeqIO  # pyright: ignore[reportMissingTypeStubs]
 
 
 def read_sequence(path: str) -> list[str]:

--- a/src/vhip/predict_interactions.py
+++ b/src/vhip/predict_interactions.py
@@ -1,9 +1,11 @@
 """Predict class."""
 
 import skops.io as sio  # pyright: ignore[reportMissingTypeStubs]
+from sklearn.ensemble import (  # pyright: ignore[reportMissingTypeStubs]
+    GradientBoostingClassifier,
+)
 
 from .mlmodel.compute_ml_features import ComputeFeatures
-from sklearn.ensemble import GradientBoostingClassifier  # pyright: ignore[reportMissingTypeStubs]
 
 
 class PredictInteractions(ComputeFeatures):

--- a/tests/test_BuildModel.py
+++ b/tests/test_BuildModel.py
@@ -1,7 +1,10 @@
 """Test suite for the BuildModel module."""
 
+from sklearn.ensemble import (  # pyright: ignore[reportMissingTypeStubs]
+    GradientBoostingClassifier,
+)
+
 from vhip.mlmodel.build import BuildModel
-from sklearn.ensemble import GradientBoostingClassifier
 
 
 def test_BuildModel_init():

--- a/tests/test_ComputeFeatures.py
+++ b/tests/test_ComputeFeatures.py
@@ -1,9 +1,9 @@
 """Test suite for the ComputeFeatures module."""
 
+import pandas as pd
+
 from vhip.mlmodel.compute_ml_features import ComputeFeatures, Pairs
 from vhip.mlmodel.genomes_features import KmerProfile
-
-import pandas as pd
 
 test_virus_directory = "tests/datatests/sequences/virus_seqs/"
 test_host_directory = "tests/datatests/sequences/host_seqs/"

--- a/tests/test_KmerProfile.py
+++ b/tests/test_KmerProfile.py
@@ -1,6 +1,9 @@
 """Pytest for genomes_features module."""
-import pytest
+from typing import List
+
 import numpy as np
+import pytest
+
 from vhip.mlmodel.genomes_features import KmerProfile
 
 
@@ -84,7 +87,7 @@ def test_KmerProfile_generate_profile():
 def test_KmerProfile_empty_string():
     """Test for empty string as input to KmerProfile."""
     # Empty string given as input
-    seq = []
+    seq: List[str] = []
     with pytest.raises(ValueError) as excinfo:
         profile = KmerProfile(seq, 3)
         profile.generate_profile()

--- a/tests/test_d2Distance.py
+++ b/tests/test_d2Distance.py
@@ -1,6 +1,7 @@
 """Pytest for d2distances measurements of k-mer profiles."""
 
 import numpy as np
+
 from vhip.mlmodel.genomes_features import KmerProfile, d2Distance
 
 

--- a/tests/test_read_sequences.py
+++ b/tests/test_read_sequences.py
@@ -1,6 +1,6 @@
 """Pytest to read sequence."""
 
-from vhip.mlmodel.read_sequence import read_sequence, read_headers
+from vhip.mlmodel.read_sequence import read_headers, read_sequence
 
 seq = """AGTACTTGTTGATGCTGATGCACTAGTTGATTCAGATGTGCTCGTACTTGTTGATTCAGACGCACTTGTG
 CTCGCTGAAGTACTATTAGATGTAGACGTGCTTGCGCTTATCGATTCAGAAGTACTTGTACTTTCTGAAC


### PR DESCRIPTION
This adds the isort (I) set of rules to Ruff. Now, running ruff --fix should automatically sort imports.

This also removes the restriction of pyright to the src folder, so files in tests and others will also be checked.