### PR TITLE
fix: Correct conditional in Publish to PyPI Release workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     # If this workflow was not triggered by a release, it's a dry run (no uploads).
-    if: ${{ github.ref_type }} == 'tag'
+    if: ${{ github.ref_type == 'tag' }}
     needs:
       - build
       - validate-tag


### PR DESCRIPTION
The conditional for the Publish to PyPI job incorrectly checked the `ref_type`. It's done correctly in the Validate tag job. This didn't cause any issues since the Publish to PyPI job requires the Validate tag job, but this fix should prevent any future issues if the dependency is removed.